### PR TITLE
PSR-4 support. Capitalized namespace. Moved helper class to Jyggen\Curl.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,10 @@
         "league/phpunit-coverage-listener": "~1.1"
     },
     "autoload": {
-        "psr-0": { "jyggen\\Curl": "src/" }
+        "psr-4": {
+            "Jyggen\\Curl\\": "src",
+            "Jyggen\\Curl\\Tests\\": "tests"
+        }
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,12 +2,12 @@
 <phpunit bootstrap="./tests/bootstrap.php">
     <testsuites>
         <testsuite name="Curl Test Suite">
-            <directory>tests/jyggen</directory>
+            <directory>tests/</directory>
         </testsuite>
     </testsuites>
     <filter>
         <whitelist>
-            <directory suffix=".php">src/jyggen</directory>
+            <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
     <logging>
@@ -24,7 +24,7 @@
                         <object class="League\PHPUnitCoverageListener\Hook\Travis"/>
                     </element>
                     <element key="namespace">
-                        <string>jyggen\Curl</string>
+                        <string>Jyggen\Curl</string>
                     </element>
                     <element key="repo_token">
                         <string>e80c563DYJSaTOw3WYvfMEko8ntneer4O</string>

--- a/src/Curl.php
+++ b/src/Curl.php
@@ -10,13 +10,13 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen;
+namespace Jyggen\Curl;
 
-use jyggen\Curl\Dispatcher;
-use jyggen\Curl\DispatcherInterface;
-use jyggen\Curl\Exception\InvalidArgumentException;
-use jyggen\Curl\Request;
-use jyggen\Curl\RequestInterface;
+use Jyggen\Curl\Dispatcher;
+use Jyggen\Curl\DispatcherInterface;
+use Jyggen\Curl\Exception\InvalidArgumentException;
+use Jyggen\Curl\Request;
+use Jyggen\Curl\RequestInterface;
 
 /**
  * Curl

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -9,11 +9,11 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl;
+namespace Jyggen\Curl;
 
-use jyggen\Curl\DispatcherInterface;
-use jyggen\Curl\Exception\CurlErrorException;
-use jyggen\Curl\Exception\InvalidArgumentException;
+use Jyggen\Curl\DispatcherInterface;
+use Jyggen\Curl\Exception\CurlErrorException;
+use Jyggen\Curl\Exception\InvalidArgumentException;
 
 /**
  * Dispatcher

--- a/src/DispatcherInterface.php
+++ b/src/DispatcherInterface.php
@@ -10,14 +10,8 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl;
+namespace Jyggen\Curl;
 
-interface RequestInterface
+interface DispatcherInterface
 {
-    /**
-     * Retrieve the cURL handle.
-     *
-     * @return curl
-     */
-    public function getHandle();
 }

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -10,7 +10,7 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl\Exception;
+namespace Jyggen\Curl\Exception;
 
 /**
  * BadMethodCallException

--- a/src/Exception/CurlErrorException.php
+++ b/src/Exception/CurlErrorException.php
@@ -10,13 +10,13 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl\Exception;
+namespace Jyggen\Curl\Exception;
 
 /**
- * InvalidArgumentException
+ * CurlErrorException
  *
- * An exception thrown if an invalid argument is passed to a method.
+ * An exception thrown if an error occurs in libcurl.
  */
-class InvalidArgumentException extends \InvalidArgumentException
+class CurlErrorException extends \Exception
 {
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -10,13 +10,13 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl\Exception;
+namespace Jyggen\Curl\Exception;
 
 /**
- * ProtectedOptionException
+ * InvalidArgumentException
  *
- * An exception thrown when trying to change a protected value or option.
+ * An exception thrown if an invalid argument is passed to a method.
  */
-class ProtectedOptionException extends \Exception
+class InvalidArgumentException extends \InvalidArgumentException
 {
 }

--- a/src/Exception/ProtectedOptionException.php
+++ b/src/Exception/ProtectedOptionException.php
@@ -10,8 +10,13 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl;
+namespace Jyggen\Curl\Exception;
 
-interface DispatcherInterface
+/**
+ * ProtectedOptionException
+ *
+ * An exception thrown when trying to change a protected value or option.
+ */
+class ProtectedOptionException extends \Exception
 {
 }

--- a/src/HeaderBag.php
+++ b/src/HeaderBag.php
@@ -10,9 +10,9 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl;
+namespace Jyggen\Curl;
 
-use jyggen\Curl\RequestInterface;
+use Jyggen\Curl\RequestInterface;
 
 /**
  * HeaderBag
@@ -24,7 +24,7 @@ class HeaderBag extends \Symfony\Component\HttpFoundation\HeaderBag
     /**
      * Which request the instance belongs to.
      *
-     * @var \jyggen\Curl\RequestInterface
+     * @var \Jyggen\Curl\RequestInterface
      */
     protected $request;
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -10,13 +10,13 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl;
+namespace Jyggen\Curl;
 
-use jyggen\Curl\Exception\CurlErrorException;
-use jyggen\Curl\Exception\ProtectedOptionException;
-use jyggen\Curl\HeaderBag;
-use jyggen\Curl\Response;
-use jyggen\Curl\RequestInterface;
+use Jyggen\Curl\Exception\CurlErrorException;
+use Jyggen\Curl\Exception\ProtectedOptionException;
+use Jyggen\Curl\HeaderBag;
+use Jyggen\Curl\Response;
+use Jyggen\Curl\RequestInterface;
 
 /**
  * Request
@@ -28,7 +28,7 @@ class Request implements RequestInterface
     /**
      * A container of headers.
      *
-     * @var \jyggen\Curl\HeaderBag
+     * @var \Jyggen\Curl\HeaderBag
      */
     public $headers;
 
@@ -67,7 +67,7 @@ class Request implements RequestInterface
     /**
      * Response object.
      *
-     * @var \jyggen\Curl\Response
+     * @var \Jyggen\Curl\Response
      */
     protected $response;
 

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -10,13 +10,14 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl\Exception;
+namespace Jyggen\Curl;
 
-/**
- * CurlErrorException
- *
- * An exception thrown if an error occurs in libcurl.
- */
-class CurlErrorException extends \Exception
+interface RequestInterface
 {
+    /**
+     * Retrieve the cURL handle.
+     *
+     * @return curl
+     */
+    public function getHandle();
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -10,9 +10,9 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl;
+namespace Jyggen\Curl;
 
-use jyggen\Curl\RequestInterface;
+use Jyggen\Curl\RequestInterface;
 
 /**
  * Response

--- a/tests/CurlTest.php
+++ b/tests/CurlTest.php
@@ -10,9 +10,9 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl\Test;
+namespace Jyggen\Curl\Test;
 
-use jyggen\Curl;
+use Jyggen\Curl\Curl;
 use Mockery as m;
 
 class CurlTest extends \PHPUnit_Framework_TestCase
@@ -26,7 +26,7 @@ class CurlTest extends \PHPUnit_Framework_TestCase
     public function testDelete()
     {
         $responses = Curl::delete('http://httpbin.org/delete');
-        $this->assertInstanceOf('jyggen\\Curl\\Response', $responses[0]);
+        $this->assertInstanceOf('Jyggen\\Curl\\Response', $responses[0]);
         $content = json_decode($responses[0]->getContent());
         $this->assertSame(JSON_ERROR_NONE, json_last_error());
         $this->assertSame('http://httpbin.org/delete', $content->url);
@@ -35,7 +35,7 @@ class CurlTest extends \PHPUnit_Framework_TestCase
     public function testGet()
     {
         $responses = Curl::get('http://httpbin.org/get');
-        $this->assertInstanceOf('jyggen\\Curl\\Response', $responses[0]);
+        $this->assertInstanceOf('Jyggen\\Curl\\Response', $responses[0]);
         $content = json_decode($responses[0]->getContent());
         $this->assertSame(JSON_ERROR_NONE, json_last_error());
         $this->assertSame('http://httpbin.org/get', $content->url);
@@ -44,7 +44,7 @@ class CurlTest extends \PHPUnit_Framework_TestCase
     public function testPost()
     {
         $responses = Curl::post('http://httpbin.org/post');
-        $this->assertInstanceOf('jyggen\\Curl\\Response', $responses[0]);
+        $this->assertInstanceOf('Jyggen\\Curl\\Response', $responses[0]);
         $content = json_decode($responses[0]->getContent());
         $this->assertSame(JSON_ERROR_NONE, json_last_error());
         $this->assertSame('http://httpbin.org/post', $content->url);
@@ -53,7 +53,7 @@ class CurlTest extends \PHPUnit_Framework_TestCase
     public function testPut()
     {
         $responses = Curl::put('http://httpbin.org/put');
-        $this->assertInstanceOf('jyggen\\Curl\\Response', $responses[0]);
+        $this->assertInstanceOf('Jyggen\\Curl\\Response', $responses[0]);
         $content = json_decode($responses[0]->getContent());
         $this->assertSame(JSON_ERROR_NONE, json_last_error());
         $this->assertSame('http://httpbin.org/put', $content->url);
@@ -62,11 +62,11 @@ class CurlTest extends \PHPUnit_Framework_TestCase
     public function testMultipleUrls()
     {
         $responses = Curl::get(array('http://httpbin.org/get?bar=foo', 'http://httpbin.org/get?foo=bar'));
-        $this->assertInstanceOf('jyggen\\Curl\\Response', $responses[0]);
+        $this->assertInstanceOf('Jyggen\\Curl\\Response', $responses[0]);
         $content = json_decode($responses[0]->getContent());
         $this->assertSame(JSON_ERROR_NONE, json_last_error());
         $this->assertSame('foo', $content->args->bar);
-        $this->assertInstanceOf('jyggen\\Curl\\Response', $responses[1]);
+        $this->assertInstanceOf('Jyggen\\Curl\\Response', $responses[1]);
         $content = json_decode($responses[1]->getContent());
         $this->assertSame(JSON_ERROR_NONE, json_last_error());
         $this->assertSame('bar', $content->args->foo);
@@ -75,7 +75,7 @@ class CurlTest extends \PHPUnit_Framework_TestCase
     public function testPostWithData()
     {
         $responses = Curl::post('http://httpbin.org/post', array('foo' => 'bar', 'bar' => 'foo'));
-        $this->assertInstanceOf('jyggen\\Curl\\Response', $responses[0]);
+        $this->assertInstanceOf('Jyggen\\Curl\\Response', $responses[0]);
         $content = json_decode($responses[0]->getContent());
         $this->assertSame(JSON_ERROR_NONE, json_last_error());
         $this->assertSame('bar', $content->form->foo);
@@ -85,7 +85,7 @@ class CurlTest extends \PHPUnit_Framework_TestCase
     public function testPutWithData()
     {
         $responses = Curl::put('http://httpbin.org/put', array('foo' => 'bar', 'bar' => 'foo'));
-        $this->assertInstanceOf('jyggen\\Curl\\Response', $responses[0]);
+        $this->assertInstanceOf('Jyggen\\Curl\\Response', $responses[0]);
         $content = json_decode($responses[0]->getContent());
         $this->assertSame(JSON_ERROR_NONE, json_last_error());
         $this->assertSame('foo=bar&bar=foo', $content->data);

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -10,9 +10,9 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl\Test;
+namespace Jyggen\Curl\Test;
 
-use jyggen\Curl\Dispatcher;
+use Jyggen\Curl\Dispatcher;
 use Mockery as m;
 
 class DispatcherTest extends \PHPUnit_Framework_TestCase
@@ -26,7 +26,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
     public function testConstruct()
     {
-        $this->assertInstanceof('jyggen\\Curl\\Dispatcher', new Dispatcher);
+        $this->assertInstanceof('Jyggen\\Curl\\Dispatcher', new Dispatcher);
     }
 
     public function testGet()
@@ -39,24 +39,24 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
     public function testAdd()
     {
         $dispatcher = new Dispatcher;
-        $request    = m::mock('jyggen\\Curl\\RequestInterface');
+        $request    = m::mock('Jyggen\\Curl\\RequestInterface');
 
         $request->shouldReceive('addMultiHandle')->andReturn(0);
 
         $this->assertEquals(0, $dispatcher->add($request));
-        $this->assertInstanceof('jyggen\\Curl\RequestInterface', $dispatcher->get(0));
+        $this->assertInstanceof('Jyggen\\Curl\RequestInterface', $dispatcher->get(0));
     }
 
     public function testClear()
     {
         $dispatcher = new Dispatcher;
-        $request    = m::mock('jyggen\\Curl\\RequestInterface');
+        $request    = m::mock('Jyggen\\Curl\\RequestInterface');
 
         $request->shouldReceive('addMultiHandle')->andReturn(0);
         $request->shouldReceive('removeMultiHandle')->andReturn(0);
 
         $this->assertEquals(0, $dispatcher->add($request));
-        $this->assertInstanceof('jyggen\\Curl\RequestInterface', $dispatcher->get(0));
+        $this->assertInstanceof('Jyggen\\Curl\RequestInterface', $dispatcher->get(0));
 
         $dispatcher->clear();
 
@@ -66,7 +66,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
     public function testRemove()
     {
         $dispatcher = new Dispatcher;
-        $request    = m::mock('jyggen\\Curl\\RequestInterface');
+        $request    = m::mock('Jyggen\\Curl\\RequestInterface');
 
         $request->shouldReceive('addMultiHandle')->andReturn(0);
         $request->shouldReceive('removeMultiHandle')->andReturn(0);
@@ -80,8 +80,8 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
     public function testExecute()
     {
         $dispatcher = new Dispatcher;
-        $request1   = m::mock('jyggen\\Curl\\Request', array('http://example.com/'))->shouldDeferMissing();
-        $request2   = m::mock('jyggen\\Curl\\Request', array('http://example.org/'))->shouldDeferMissing();
+        $request1   = m::mock('Jyggen\\Curl\\Request', array('http://example.com/'))->shouldDeferMissing();
+        $request2   = m::mock('Jyggen\\Curl\\Request', array('http://example.org/'))->shouldDeferMissing();
 
         $request1->shouldReceive('execute')->andReturn(true);
         $request2->shouldReceive('execute')->andReturn(true);
@@ -104,7 +104,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        jyggen\Curl\Exception\CurlErrorException
+     * @expectedException        Jyggen\Curl\Exception\CurlErrorException
      * @expectedExceptionMessage Unable to add request to cURL multi handle (code #4)
      */
     public function testExecuteWithError()
@@ -113,8 +113,8 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
 
         $mockAddMulti = true;
         $dispatcher   = new Dispatcher;
-        $request1     = m::mock('jyggen\\Curl\\Request', array('http://example.com/'))->shouldDeferMissing();
-        $request2     = m::mock('jyggen\\Curl\\Request', array('http://example.org/'))->shouldDeferMissing();
+        $request1     = m::mock('Jyggen\\Curl\\Request', array('http://example.com/'))->shouldDeferMissing();
+        $request2     = m::mock('Jyggen\\Curl\\Request', array('http://example.org/'))->shouldDeferMissing();
 
         $dispatcher->add($request1);
         $dispatcher->add($request2);
@@ -129,7 +129,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        jyggen\Curl\Exception\InvalidArgumentException
+     * @expectedException        Jyggen\Curl\Exception\InvalidArgumentException
      * @expectedExceptionMessage setStackSize() expected an integer
      */
     public function testSetStackSizeInvalidArgument()

--- a/tests/HeaderBagTest.php
+++ b/tests/HeaderBagTest.php
@@ -10,9 +10,9 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl\Test;
+namespace Jyggen\Curl\Test;
 
-use jyggen\Curl\HeaderBag;
+use Jyggen\Curl\HeaderBag;
 use Mockery as m;
 
 class HeaderBagTest extends \PHPUnit_Framework_TestCase
@@ -28,9 +28,9 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
     public function testConstruct()
     {
 
-        $request   = m::mock('jyggen\\Curl\\RequestInterface');
+        $request   = m::mock('Jyggen\\Curl\\RequestInterface');
         $headerbag = new HeaderBag(array(), $request);
-        $this->assertInstanceof('jyggen\\Curl\\HeaderBag', $headerbag);
+        $this->assertInstanceof('Jyggen\\Curl\\HeaderBag', $headerbag);
 
     }
 
@@ -38,7 +38,7 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
     {
 
         $phpunit   = $this;
-        $request   = m::mock('jyggen\\Curl\\RequestInterface');
+        $request   = m::mock('Jyggen\\Curl\\RequestInterface');
         $headerbag = new HeaderBag(array(), $request);
         $request->shouldReceive('setOption')->times(1)->with(m::mustBe(CURLOPT_HTTPHEADER), m::type('array'));
         $headerbag->set('foo', 'bar');
@@ -49,7 +49,7 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
     {
 
         $phpunit   = $this;
-        $request   = m::mock('jyggen\\Curl\\RequestInterface');
+        $request   = m::mock('Jyggen\\Curl\\RequestInterface');
         $headerbag = new HeaderBag(array(), $request);
         $request->shouldReceive('setOption')->times(1)->with(m::mustBe(CURLOPT_HTTPHEADER), m::type('array'));
         $headerbag->remove('foo');

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -10,9 +10,9 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl\Test;
+namespace Jyggen\Curl\Test;
 
-use jyggen\Curl\Request;
+use Jyggen\Curl\Request;
 use Mockery as m;
 
 class RequestTest extends \PHPUnit_Framework_TestCase
@@ -28,7 +28,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testConstruct()
     {
 
-        $this->assertInstanceof('jyggen\\Curl\\RequestInterface', $this->forgeRequest());
+        $this->assertInstanceof('Jyggen\\Curl\\RequestInterface', $this->forgeRequest());
 
     }
 
@@ -88,7 +88,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        jyggen\Curl\Exception\CurlErrorException
+     * @expectedException        Jyggen\Curl\Exception\CurlErrorException
      * @expectedExceptionMessage Couldn't set option
      */
     public function testSetOptionError()
@@ -100,7 +100,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        jyggen\Curl\Exception\CurlErrorException
+     * @expectedException        Jyggen\Curl\Exception\CurlErrorException
      * @expectedExceptionMessage Couldn't set option
      */
     public function testSetOptionArrayError()
@@ -112,7 +112,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        jyggen\Curl\Exception\ProtectedOptionException
+     * @expectedException        Jyggen\Curl\Exception\ProtectedOptionException
      * @expectedExceptionMessage protected option
      */
     public function testSetProtectedOption()
@@ -140,7 +140,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        jyggen\Curl\Exception\CurlErrorException
+     * @expectedException        Jyggen\Curl\Exception\CurlErrorException
      * @expectedExceptionMessage resolve host
      */
     public function testExecuteWithError()

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -10,9 +10,9 @@
  * @link        http://github.com/jyggen/curl
  */
 
-namespace jyggen\Curl\Test;
+namespace Jyggen\Curl\Test;
 
-use jyggen\Curl\Response;
+use Jyggen\Curl\Response;
 use Mockery as m;
 
 class ResponseTest extends \PHPUnit_Framework_TestCase
@@ -28,7 +28,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     public function testForge()
     {
 
-        $request   = m::mock('jyggen\\Curl\\RequestInterface');
+        $request   = m::mock('Jyggen\\Curl\\RequestInterface');
         $response  = 'HTTP/1.1 503 Service Temporarily Unavailable'."\r\n";
         $response .= 'Server: nginx'."\r\n";
         $response .= 'Date: Tue, 19 Feb 2013 12:59:40 GMT'."\r\n";

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,5 @@
 <?php
-namespace jyggen\Curl {
+namespace Jyggen\Curl {
 
     require_once './vendor/autoload.php';
 


### PR DESCRIPTION
Will merge this eventually. This will bump the package to 4.0, no doubt, and break everything everywhere.
#### PSR-4 Support?

It's new and pretty. Won't break anything by itself.
#### Capitalized Namespace?

Because lowercase namespaces are weird. `jyggen\Curl` will turn into `Jyggen\Curl`.
#### Moved helper class?

Yes. `jyggen\Curl` is now `Jyggen\Curl\Curl` to keep everything in the namespace.
