### PR TITLE
Fix `Undefined offset` PHP error

### DIFF
--- a/lib/jyggen/Curl/Response.php
+++ b/lib/jyggen/Curl/Response.php
@@ -53,7 +53,7 @@ class Response extends \Symfony\Component\HttpFoundation\Response
 
         foreach ($headers as $header) {
 
-            list($key, $value)     = explode(': ', $header);
+            list($key, $value)     = array_pad(explode(':', $header), 2, '');
             $headerBag[trim($key)] = trim($value);
 
         }


### PR DESCRIPTION
Fix `Undefined offset` PHP error when HTTP response has a malformed header with empty value. Like some HTTP responses from Github with `X-Geo-Block-List:\r\n` header.

cf. https://github.com/erengy/taiga/issues/273#issuecomment-226141146 for similar case.
